### PR TITLE
Corrected UTF-8 Encoding

### DIFF
--- a/align.py
+++ b/align.py
@@ -217,10 +217,10 @@ def recursively_find_match(script, subs, result, first_script, last_script, firs
     # t.refresh()
 
 def run(split_script, subs_file, out, mode=2):
-    with open(split_script) as s:
+    with open(split_script, encoding='utf-8') as s:
         script = [ScriptLine(line.strip()) for line in read_script(s)]
     print(subs_file)
-    with open(subs_file) as vtt:
+    with open(subs_file, encoding='utf-8') as vtt:
         subs = read_vtt(vtt)
     new_subs = []
 

--- a/run.py
+++ b/run.py
@@ -78,7 +78,7 @@ def combine_vtt(vtt_files, offsets, output_file_path):
     subs = []
 
     for n, vtt_file in enumerate(vtt_files):
-        with open(vtt_file) as vtt:
+        with open(vtt_file, encoding='utf-8') as vtt:
             latest_subs = read_vtt(vtt)
             last_offset = offsets[n]
             subs += adjust_timings(latest_subs, last_offset)

--- a/utils.py
+++ b/utils.py
@@ -65,7 +65,7 @@ def read_vtt(file):
 
 
 def write_sub(output_file_path, subs):
-    with open(output_file_path, "w") as outfile:
+    with open(output_file_path, "w", encoding='utf-8') as outfile:
         outfile.write('WEBVTT\n\n')
         for n, sub in enumerate(subs):
             # outfile.write('%d\n' % (n + 1))


### PR DESCRIPTION
Prevented errors on Windows from the system defaulting to encoding format(s) other than UTF-8 inducing UnicodeEncodeError and UnicodeDecodeErrors.  Fixed by passing encoding arguments in three of the python scripts preventing unicode strings being interpreted as other than UTF-8.