### PR TITLE
Add audio file naming sanity check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,9 +42,9 @@ Primarily I'm using this for syncing audiobooks to their book script. So while y
 
 1. `git clone https://github.com/kanjieater/AudiobookTextSync.git`
 1. Make sure you run any commands that start with `./` from the project root, eg after you clone you can run `cd ./AudiobookTextSync`
-1. Setup the folder. Create a folder to hold a single media file (like an audiobook). Name it whatever you name your media file, eg `Arslan Senki 7`, this is what should go anywhere you see me write `<name>`
+1. Setup the folder. Create a folder to hold a single media file (like an audiobook). Name it whatever you name your media file, eg `Arslan Senki 7`, this is what should go anywhere you see me write `<name>`.
 1. Get the book script as text from a digital copy. Put the script at: `./<name>/script.txt`. Everything in this file will show up in your subtitles. So it's important you trim out excess (table of contents, character bios that aren't in the audiobook etc)
-1. Single media file should be in `./<name>/<name>.m4b`. If you have the split audiobook as m4b,mp3, or mp4's you can run `./merge.sh "<full folder path>"`,
+1. Single media file should be in `./<name>/<name>.m4b`. If you have the split audiobook as m4b, mp3, or mp4's you can run `./merge.sh "<full folder path>"`,
  eg `./merge.sh "/mnt/d/Editing/Audiobooks/ｍｅｄｉｕｍ霊媒探偵城塚翡翠"`. The split files must be in `./<name>/<name>_merge/`. This will merge your file into a single file so it can be processed.
 6. If you have the `script.txt` and either `./<name>/<name>.m4b`, you can now run the GPU intense, time intense, and occasionally CPU intense script part. `python run.py -d "<full folder path>"` eg `python run.py -d "/mnt/d/Editing/Audiobooks/かがみの孤城/"`. This runs each file to get a word level transcript. It then creates a sub format that can be matched to the `script.txt`. Each word level subtitle is merged into a phrase level, and your result should be a `<name>.srt` file that can be watched with `MPV`, showing audio in time with the full book as a subtitle.
 7. From there, use a [texthooker](https://github.com/Renji-XD/texthooker-ui) with something like [mpv_websocket](https://github.com/kuroahna/mpv_websocket) and enjoy Immersion Reading.
@@ -58,7 +58,7 @@ Primarily I'm using this for syncing audiobooks to their book script. So while y
 # Single File
 
 You can also run for a single file. Beware if it's over 1GB/19hr you need as much as 8GB of RAM available.
-You need your`m4b`, `mp3`, or `mp4` audiobook file to be inside the folder: "<full folder path>", with a `txt` file in the same folder. The `txt` file can be named anything as long as it has a `txt` extension.
+You need your audio file to be inside a folder with the **same name as the audiofile**, in addition to a `txt` file in the same folder. The `txt` file can be named anything as long as it has a `txt` extension.
 The `-d` parameter can multiple audiobooks to process like: `python run.py -d "/mnt/d/sync/Harry Potter 1/" "/mnt/d/sync/Harry Potter 2 The Spooky Sequel/"`
 ```bash
 /sync/

--- a/run.py
+++ b/run.py
@@ -317,7 +317,7 @@ if __name__ == "__main__":
             print(f"Working on {working_folder}")
             
             # Ensure audio file(s) have the same name as the working dir
-            check_verdict = check_workdir_content(working_folder)
+            check_verdict = check_workdir_content(working_folder, SUPPORTED_FORMATS)
             
             if not check_verdict:
                 expected_file_name_base = path.basename(path.normpath(working_folder))

--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from tqdm.contrib.concurrent import process_map
 from tqdm import tqdm
 from pprint import pprint
-from utils import read_vtt, write_sub, grab_files
+from utils import read_vtt, write_sub, grab_files, check_workdir_content
 from split_sentences import split_sentences
 import align
 import traceback
@@ -19,7 +19,7 @@ SUPPORTED_FORMATS = ["*.mp3", "*.m4b", "*.mp4"]
 
 def get_model(model_type='large-v2'):
     return stable_whisper.load_model(model_type)
-    # return stable_whisper.load_faster_whisper(model_type)
+    # return stable_whisper.load_faster_whisper(model_type)    
 
 def generate_transcript_from_audio(audio_file, full_timings_path, model, sub_format='ass', **kwargs):
     default_args = {
@@ -315,6 +315,16 @@ if __name__ == "__main__":
     for working_folder in working_folders:
         try:
             print(f"Working on {working_folder}")
+            
+            # Ensure audio file(s) have the same name as the working dir
+            check_verdict = check_workdir_content(working_folder)
+            
+            if not check_verdict:
+                expected_file_name_base = path.basename(path.normpath(working_folder))
+                print("> ERROR: Current working directory does not contain an audio file of the same name.")
+                print(f"  Your audio file must have the same name as this directory, e.g. '{expected_file_name_base}.m4b'")
+                continue
+            
             split_txt(working_folder)
             if args.use_stable_ts_align:
                 align_stable_transcript(working_folder, get_content_name(working_folder))

--- a/utils.py
+++ b/utils.py
@@ -1,12 +1,12 @@
 import re
 from natsort import os_sorted
 from glob import glob, escape
+from os import path
 import json
 
 audio_formats = ['aac', 'ac3', 'alac', 'ape', 'flac', 'mp3', 'm4a', 'ogg', 'opus', 'wav', 'm4b']
 video_formats = ['3g2', '3gp', 'avi', 'flv', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'webm']
 subtitle_formats = ['ass', 'srt', 'vtt']
-
 
 class Subtitle:
     def __init__(self, start, end, line):
@@ -14,15 +14,18 @@ class Subtitle:
         self.end = end
         self.line = line
 
+def check_workdir_content(workdir):
+    workdir_stripped = path.basename(path.normpath(workdir))    
+    files = glob(f"{workdir.rstrip('/')}/*{workdir_stripped}*")
+
+    return len(files) > 0
 
 def remove_tags(line):
     return re.sub('<[^>]*>', '', line)
 
-
 def get_lines(file):
     for line in file:
         yield line.rstrip('\n')
-
 
 def read_vtt(file):
     lines = get_lines(file)
@@ -68,7 +71,6 @@ def read_vtt(file):
 
     return subs
 
-
 def write_sub(output_file_path, subs):
     with open(output_file_path, "w", encoding='utf-8') as outfile:
         outfile.write('WEBVTT\n\n')
@@ -76,7 +78,6 @@ def write_sub(output_file_path, subs):
             # outfile.write('%d\n' % (n + 1))
             outfile.write('%s --> %s\n' % (sub.start, sub.end))
             outfile.write('%s\n\n' % (sub.line))
-
 
 def grab_files(folder, types, sort=True):
     files = []

--- a/utils.py
+++ b/utils.py
@@ -14,9 +14,14 @@ class Subtitle:
         self.end = end
         self.line = line
 
-def check_workdir_content(workdir):
-    workdir_stripped = path.basename(path.normpath(workdir))    
-    files = glob(f"{workdir.rstrip('/')}/*{workdir_stripped}*")
+def check_workdir_content(workdir, formats):
+    workdir_stripped = path.basename(path.normpath(workdir))
+    
+    files = []
+    for format in formats:
+        result = glob(f"{workdir.rstrip('/')}/*{workdir_stripped}.{format}")
+        if len(result) > 0:
+            files.append(result)
 
     return len(files) > 0
 


### PR DESCRIPTION
Added:
- Sanity check to ensure audio file naming is `path/to/audibook/<name>/<name>.mb4`.  
- Explicit mention in guide that audio file needs to have the same name as its parent folder in section `Single File`, along with sporadic typo corrections.

A failing check will produce the following error:
```bash
$ python run.py -d ~/Downloads/
Working on /home/user/Downloads/
> ERROR: Current working directory does not contain an audio file of the same name.
  Your audio file must have the same name as this directory, e.g. 'Downloads.m4b'
```